### PR TITLE
add/pagination

### DIFF
--- a/app/admin/products/page.tsx
+++ b/app/admin/products/page.tsx
@@ -8,6 +8,7 @@ import ProductFilters from "../../../components/admin/ProductFilters";
 import ProductListItem from "../../../components/admin/ProductListItem";
 import StatusModal from "../../../components/admin/StatusModal";
 import DeployStatusModal from "../../../components/admin/DeployStatusModal";
+import Pagination from "../../../components/Pagination";
 import { useProductManagement, Product } from "../../../hooks/useProductManagement";
 import { useTechnologyManagement } from "../../../hooks/useTechnologyManagement";
 import { useProductFilters } from "../../../hooks/useProductFilters";
@@ -71,6 +72,10 @@ function ProductsContent() {
   const [statusModalProduct, setStatusModalProduct] = useState<Product | null>(null);
   const [deployStatusModalProduct, setDeployStatusModalProduct] = useState<Product | null>(null);
 
+  // ページネーション用のstate
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 10;
+
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === "Escape" && (isAddingNew || editingProduct)) {
@@ -85,6 +90,17 @@ function ProductsContent() {
   const safeProducts = Array.isArray(products) ? products : [];
   const availableYears = Array.from(new Set(safeProducts.map(p => p.createdYear).filter(Boolean))).sort((a, b) => b! - a!);
   const availableMonths = Array.from(new Set(safeProducts.map(p => p.createdMonth).filter(Boolean))).sort((a, b) => a! - b!);
+
+  // ページネーション計算
+  const totalPages = Math.ceil(filteredProducts.length / itemsPerPage);
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const endIndex = startIndex + itemsPerPage;
+  const currentProducts = filteredProducts.slice(startIndex, endIndex);
+
+  // フィルター変更時にページを1に戻す
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [filterCategory, filterTechnologies, filterStatus, filterDeployStatus, filterCreatedYear, filterCreatedMonth, sortBy]);
 
   if (loading) {
     return (
@@ -162,7 +178,7 @@ function ProductsContent() {
             <h2 className="text-base sm:text-xl font-semibold truncate">作品一覧（{filteredProducts.length}件 / 全{safeProducts.length}件）</h2>
           </div>
           <div className="divide-y">
-            {filteredProducts.map((product) => (
+            {currentProducts.map((product) => (
               <ProductListItem
                 key={product.id}
                 product={product}
@@ -173,6 +189,18 @@ function ProductsContent() {
               />
             ))}
           </div>
+
+          {/* ページネーション */}
+          {filteredProducts.length > itemsPerPage && (
+            <div className="px-3 py-4 sm:px-6 sm:py-5 border-t">
+              <Pagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={setCurrentPage}
+                variant="admin"
+              />
+            </div>
+          )}
         </div>
 
         {statusModalProduct && (

--- a/app/product/page.tsx
+++ b/app/product/page.tsx
@@ -5,6 +5,7 @@ import FadeInSection from "../../components/FadeInSection";
 import ProductCard from "../../components/ProductCard";
 import SiteLayout from "../../components/layouts/SiteLayout";
 import Accordion from "../../components/Accordion";
+import Pagination from "../../components/Pagination";
 
 interface Product {
   id: string;
@@ -47,6 +48,10 @@ export default function ProductSection() {
   const [filterStatus, setFilterStatus] = useState(""); // 一旦すべて表示
   const [filterYear, setFilterYear] = useState("");
   const [sortBy, setSortBy] = useState("createdYear-desc"); // 新しい順に変更
+
+  // ページネーション用のstate
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 6;
 
   useEffect(() => {
     fetchProducts();
@@ -170,6 +175,17 @@ export default function ProductSection() {
         .filter(Boolean)
     )
   ).sort((a, b) => b! - a!);
+
+  // ページネーション計算
+  const totalPages = Math.ceil(filteredProducts.length / itemsPerPage);
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const endIndex = startIndex + itemsPerPage;
+  const currentProducts = filteredProducts.slice(startIndex, endIndex);
+
+  // フィルター変更時にページを1に戻す
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [filterCategory, filterTechnologies, filterStatus, filterYear, sortBy]);
 
   if (loading) {
     return (
@@ -298,12 +314,24 @@ export default function ProductSection() {
             </div>
           </Accordion>
 
+
+          {/* ページネーション */}
+          {filteredProducts.length > itemsPerPage && (
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={setCurrentPage}
+              variant="public"
+              className="mt-8 mb-4"
+            />
+          )}
+
           {/* 作品一覧 */}
           <div className="grid-card">
-            {filteredProducts.length === 0 ? (
+            {currentProducts.length === 0 ? (
               <p className="text-center text-gray-500 py-8">該当する作品がありません</p>
             ) : (
-              filteredProducts.map((product: Product) => (
+              currentProducts.map((product: Product) => (
                 <ProductCard
                   key={product.id}
                   title={product.title}
@@ -320,6 +348,17 @@ export default function ProductSection() {
               ))
             )}
           </div>
+
+          {/* ページネーション */}
+          {filteredProducts.length > itemsPerPage && (
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={setCurrentPage}
+              variant="public"
+              className="mt-8 mb-4"
+            />
+          )}
         </section>
       </FadeInSection>
     </SiteLayout >

--- a/components/Pagination.tsx
+++ b/components/Pagination.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  className?: string;
+  variant?: "admin" | "public";
+}
+
+export default function Pagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+  className = "",
+  variant = "admin",
+}: PaginationProps) {
+  // ページ番号の配列を生成（省略表示対応）
+  const getPageNumbers = () => {
+    const pages: (number | string)[] = [];
+    const maxVisible = 5; // 表示する最大ページ数
+
+    if (totalPages <= maxVisible + 2) {
+      // ページ数が少ない場合はすべて表示
+      for (let i = 1; i <= totalPages; i++) {
+        pages.push(i);
+      }
+    } else {
+      // ページ数が多い場合は省略表示
+      if (currentPage <= 3) {
+        // 現在のページが先頭付近
+        for (let i = 1; i <= maxVisible; i++) {
+          pages.push(i);
+        }
+        pages.push("...");
+        pages.push(totalPages);
+      } else if (currentPage >= totalPages - 2) {
+        // 現在のページが末尾付近
+        pages.push(1);
+        pages.push("...");
+        for (let i = totalPages - maxVisible + 1; i <= totalPages; i++) {
+          pages.push(i);
+        }
+      } else {
+        // 現在のページが中間
+        pages.push(1);
+        pages.push("...");
+        for (let i = currentPage - 1; i <= currentPage + 1; i++) {
+          pages.push(i);
+        }
+        pages.push("...");
+        pages.push(totalPages);
+      }
+    }
+
+    return pages;
+  };
+
+  const pageNumbers = getPageNumbers();
+
+  // バリアント別のスタイル
+  const buttonStyles = {
+    admin: {
+      base: "px-2 py-1 sm:px-3 sm:py-2 text-sm border rounded-md transition-all duration-200",
+      active: "bg-blue-600 text-white border-blue-600",
+      inactive: "border-gray-300 hover:bg-gray-100 hover:border-gray-400",
+      disabled: "disabled:opacity-50 disabled:cursor-not-allowed",
+    },
+    public: {
+      base: "px-3 py-2 text-sm border rounded-lg transition-all duration-200 font-medium shadow-sm",
+      active: "bg-[var(--primary-color)] text-white border-[var(--primary-color)] shadow-md",
+      inactive: "border-[var(--card-border)] bg-white hover:bg-[var(--primary-light)] hover:border-[var(--primary-color)] hover:shadow-md",
+      disabled: "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-white disabled:hover:border-[var(--card-border)] disabled:hover:shadow-sm",
+    },
+  };
+
+  const styles = buttonStyles[variant];
+
+  return (
+    <div className={`flex justify-center items-center gap-1 sm:gap-2 ${className}`}>
+      {/* 前へボタン */}
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+        className={`${styles.base} ${styles.disabled} ${styles.inactive}`}
+        aria-label="前のページ"
+      >
+        <span className="hidden sm:inline">前へ</span>
+        <span className="sm:hidden">‹</span>
+      </button>
+
+      {/* ページ番号 */}
+      <div className="flex gap-1 sm:gap-2">
+        {pageNumbers.map((page, index) => {
+          if (page === "...") {
+            return (
+              <span
+                key={`ellipsis-${index}`}
+                className={`px-2 py-1 sm:px-3 sm:py-2 text-sm flex items-center ${
+                  variant === "public" ? "text-[var(--text-body)]" : "text-gray-500"
+                }`}
+              >
+                ...
+              </span>
+            );
+          }
+
+          const pageNum = page as number;
+          return (
+            <button
+              key={pageNum}
+              onClick={() => onPageChange(pageNum)}
+              className={`${styles.base} ${
+                currentPage === pageNum ? styles.active : styles.inactive
+              }`}
+              aria-label={`ページ ${pageNum}`}
+              aria-current={currentPage === pageNum ? "page" : undefined}
+            >
+              {pageNum}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 次へボタン */}
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+        className={`${styles.base} ${styles.disabled} ${styles.inactive}`}
+        aria-label="次のページ"
+      >
+        <span className="hidden sm:inline">次へ</span>
+        <span className="sm:hidden">›</span>
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📊 Pull Request 実装状況レポート
## 🟢 **実装完了**

### Issues #28 : paginationの実装

- [x] ページネーションを実装し、一般公開ページでは6件ごとadminページでは10件ごとに次のページにすることができるように修正した。

---

## 🏗️ **追加実装内容**

###
 
---

## 🧪 **動作確認済み機能**

- [x] 10件以上登録した後、各種productページを確認しpaginationが正常に動作することを確認。

## 関連Issues
fix #28 