### PR TITLE
fix/hamburger_menu_backcolor

### DIFF
--- a/components/SlideInMenu.tsx
+++ b/components/SlideInMenu.tsx
@@ -86,7 +86,7 @@ export default function SlideInMenu({ isOpen, onClose, ariaLabel, children }: Sl
         role="dialog"
         aria-modal="true"
         aria-label={ariaLabel}
-        className={`absolute right-0 top-0 h-full w-80 bg-primary-light text-header-color shadow-lg pt-16 px-7 pb-7 flex flex-col space-y-6 text-xl transition-transform duration-200 ease-out ${
+        className={`absolute right-0 top-0 h-full w-80 bg-[var(--card-background)] text-header-color shadow-lg pt-16 px-7 pb-7 flex flex-col space-y-6 text-xl transition-transform duration-200 ease-out ${
           isOpen ? "translate-x-0" : "translate-x-full"
         }`}
       >


### PR DESCRIPTION
## 📊 Pull Request 実装状況レポート
## 🟢 **実装完了**

### ハンバーガーメニューの背景色の変更

- [x] 背景色が透明であり、文字の視認性が悪くなってしまっていたため、`backgroundcolor`へと統一した。

---

## 🏗️ **追加実装内容**

###
 
---

## 🧪 **動作確認済み機能**

- [x] ハンバーガーメニューを展開し、色彩を確認した。

## 関連Issues
fix #13 